### PR TITLE
Token Headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Changed token url to being tokens in authorization headers.
 
 ## [0.7.0]
 ### Added

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -37,6 +37,7 @@ class Query(object):
         self._route = route
         self.mode(mode)
         self.concept_id_chars = []
+        self.headers = None
 
     def get(self, limit=2000):
         """
@@ -53,7 +54,7 @@ class Query(object):
         page = 1
         while len(results) < limit:
 
-            response = get(url, params={'page_size': page_size, 'page_num': page})
+            response = get(url, headers=self.headers, params={'page_size': page_size, 'page_num': page})
 
             try:
                 response.raise_for_status()
@@ -83,7 +84,7 @@ class Query(object):
 
         url = self._build_url()
 
-        response = get(url, params={'page_size': 0})
+        response = get(url, headers=self.headers, params={'page_size': 0})
 
         try:
             response.raise_for_status()
@@ -273,16 +274,17 @@ class Query(object):
 
     def token(self, token):
         """
-        Add token into url request.
+        Add token into authorization headers.
 
-        :param token: Token from EDL.
+        :param token: Token from EDL or NASA Launchpad token.
         :returns: Query instance
         """
 
         if not token:
             return self
 
-        self.params['token'] = token
+        self.headers = {'Authorization': token}
+
         return self
 
 class GranuleCollectionBaseQuery(Query):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -88,5 +88,5 @@ class TestCollectionClass(unittest.TestCase):
 
         query.token("123TOKEN")
 
-        self.assertIn("token", query.params)
-        self.assertEqual(query.params["token"], "123TOKEN")
+        self.assertIn("Authorization", query.headers)
+        self.assertEqual(query.headers["Authorization"], "123TOKEN")

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -433,6 +433,5 @@ class TestGranuleClass(unittest.TestCase):
         query = GranuleQuery()
 
         query.token("123TOKEN")
-
-        self.assertIn("token", query.params)
-        self.assertEqual(query.params["token"], "123TOKEN")
+        self.assertIn("Authorization", query.headers)
+        self.assertEqual(query.headers["Authorization"], "123TOKEN")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -75,5 +75,5 @@ class TestServiceClass(unittest.TestCase):
 
         query.token("123TOKEN")
 
-        self.assertIn("token", query.params)
-        self.assertEqual(query.params["token"], "123TOKEN")
+        self.assertIn("Authorization", query.headers)
+        self.assertEqual(query.headers["Authorization"], "123TOKEN")

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -75,5 +75,5 @@ class TestToolClass(unittest.TestCase):
 
         query.token("123TOKEN")
 
-        self.assertIn("token", query.params)
-        self.assertEqual(query.params["token"], "123TOKEN")
+        self.assertIn("Authorization", query.headers)
+        self.assertEqual(query.headers["Authorization"], "123TOKEN")

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -75,5 +75,5 @@ class TestVariableClass(unittest.TestCase):
 
         query.token("123TOKEN")
 
-        self.assertIn("token", query.params)
-        self.assertEqual(query.params["token"], "123TOKEN")
+        self.assertIn("Authorization", query.headers)
+        self.assertEqual(query.headers["Authorization"], "123TOKEN")


### PR DESCRIPTION
- Change tokens from being in url to added to headers in api requests to support launchpad tokens