### PR TITLE
Add cmr environments to module level

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ The following methods are available to both collecton and granule queries:
 
     # search by provider
     >>> api.provider('POCLOUD')
+    
+    # search non-ops CMR environment
+    >>> from cmr import CMR_UAT
+    >>> api.mode(CMR_UAT)
 
 Granule searches support these methods (in addition to the shared methods above):
 

--- a/cmr/__init__.py
+++ b/cmr/__init__.py
@@ -1,3 +1,3 @@
-from .queries import GranuleQuery, CollectionQuery, ToolQuery, ServiceQuery, VariableQuery
+from .queries import GranuleQuery, CollectionQuery, ToolQuery, ServiceQuery, VariableQuery, CMR_OPS, CMR_UAT, CMR_SIT
 
-__all__ = ["GranuleQuery", "CollectionQuery", "ToolQuery", "ServiceQuery", "VariableQuery"]
+__all__ = ["GranuleQuery", "CollectionQuery", "ToolQuery", "ServiceQuery", "VariableQuery", "CMR_OPS", "CMR_UAT", "CMR_SIT"]


### PR DESCRIPTION
Allows for `from cmr import CMR_UAT` instead of `from cmr.queries import CMR_UAT`