### PR TITLE
New searching criterion: circle

### DIFF
--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -417,6 +417,18 @@ class GranuleCollectionBaseQuery(Query):
 
         return self
 
+    def circle(self, lon: float, lat: float, dist: int):
+        """Filter by granules within the circle around lat/lon
+
+        :param lon: longitude of geographic point
+        :param lat: latitude of geographic point
+        :param dist: distance in meters around waypoint (lat,lon)
+        :returns: Query instance
+        """
+        self.params['circle'] = f"{lon},{lat},{dist}"
+
+        return self
+
     def polygon(self, coordinates):
         """
         Filter by granules that overlap a polygonal area. Must be used in combination with a

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -12,6 +12,7 @@ class TestGranuleClass(unittest.TestCase):
     version = "version"
 
     point = "point"
+    circle = "circle"
     online_only = "online_only"
     downloadable = "downloadable"
     entry_id = "entry_title"
@@ -50,6 +51,14 @@ class TestGranuleClass(unittest.TestCase):
         with self.assertRaises(ValueError):
             query.point("invalid", 15.1)
             query.point(10, None)
+
+    def test_circle_set(self):
+        query = GranuleQuery()
+
+        query.circle(10.0, 15.1, 1000)
+
+        self.assertIn(self.circle, query.params)
+        self.assertEqual(query.params[self.circle], "10.0,15.1,1000")
 
     def test_temporal_invalid_strings(self):
         query = GranuleQuery()
@@ -334,6 +343,9 @@ class TestGranuleClass(unittest.TestCase):
         query = GranuleQuery()
 
         query.point(1, 2)
+        self.assertFalse(query._valid_state())
+
+        query.circle(1, 2, 3)
         self.assertFalse(query._valid_state())
 
         query.polygon([(1, 1), (2, 1), (2, 2), (1, 1)])


### PR DESCRIPTION
Similar to the point criterion but includes a buffer around the point. One application is searching for granules with data within a certain distance of a waypoint such as a mooring or a meteorological station.