### PR TITLE
add readable_granule_name option to GranuleQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [pull/27](https://github.com/nasa/python_cmr/pull/27) New feature to search by `readable_granlue_name` https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#g-granule-ur-or-producer-granule-id
 
 ## [0.9.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ### Added
 - [pull/27](https://github.com/nasa/python_cmr/pull/27) New feature to search by `readable_granlue_name` https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#g-granule-ur-or-producer-granule-id
+### Fixed
+- [pull/27](https://github.com/nasa/python_cmr/pull/27) Fixed bug with constructing the `options` sent to CMR which was causing filters to not get applied correctly.
 
 ## [0.9.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Granule searches support these methods (in addition to the shared methods above)
     >>> api.granule_ur("SC:AST_L1T.003:2150315169")
     # search for granules from a specific orbit
     >>> api.orbit_number(5000)
+    # search for a granule by name
+    >>> api.short_name("MOD09GA").readable_granule_name(["*h32v08*","*h30v13*"])
 
     # filter by the day/night flag
     >>> api.day_night_flag("day")

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -203,7 +203,7 @@ class Query(object):
                 formatted_options.append("options[{}][{}]={}".format(
                     param_key,
                     option_key,
-                    val
+                    str(val).lower()
                 ))
 
         options_as_string = "&".join(formatted_options)
@@ -740,6 +740,27 @@ class GranuleQuery(GranuleCollectionBaseQuery):
             raise ValueError("Please provide a value for platform")
 
         self.params['granule_ur'] = granule_ur
+        return self
+    
+    def readable_granule_name(self, readable_granule_name=""):
+        """
+        Filter by the readable granule name (producer_granule_id if present, otherwise producer_granule_id).
+
+        Can use wildcards for substring matching:
+
+        asterisk (*) will match any number of characters.
+        question mark (?) will match exactly one character.
+
+        :param readable_granule_name: granule name or substring
+        :returns: Query instance
+        """
+
+        if isinstance(readable_granule_name, str):
+            readable_granule_name = [readable_granule_name]
+        
+        self.params["readable_granule_name"] = readable_granule_name
+        self.options["readable_granule_name"] = {"pattern": True}
+
         return self
 
     def _valid_state(self):

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -22,6 +22,7 @@ class TestGranuleClass(unittest.TestCase):
     instrument = "instrument"
     platform = "platform"
     granule_ur = "granule_ur"
+    readable_granule_name = "readable_granule_name"
 
     sort_key="sort_key"
 
@@ -448,6 +449,11 @@ class TestGranuleClass(unittest.TestCase):
         self.assertNotIn("True", url)
         self.assertNotIn("False", url)
 
+        # ensure True is not found with parameters that add to options
+        query.parameters(readable_granule_name="A")
+        url = query._build_url()
+        self.assertNotIn("True", url)
+
     def test_valid_concept_id(self):
         query = GranuleQuery()
 
@@ -472,3 +478,13 @@ class TestGranuleClass(unittest.TestCase):
         self.assertIn("Authorization", query.headers)
         self.assertEqual(query.headers["Authorization"], "Bearer 123TOKEN")
 
+    def test_readable_granule_name(self):
+        query = GranuleQuery()
+
+        query.readable_granule_name("*a*")
+        self.assertEqual(query.params[self.readable_granule_name], ["*a*"])
+        self.assertIn("pattern", query.options["readable_granule_name"])
+        self.assertEqual(query.options["readable_granule_name"]["pattern"], True)
+
+        query.readable_granule_name(["*a*", "*b*"])
+        self.assertEqual(query.params[self.readable_granule_name], ["*a*", "*b*"])


### PR DESCRIPTION
# Description
Adds the option to use GranuleQuery and [filter using readable_granule_name](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#g-granule-ur-or-producer-granule-id)

This opens up options like query MODIS ids based on H/V coords or search by ID and other sub-string searches.

Additionally fix options formatting to force lowercase. This was required to get this filter working and lowercase appears to be the required format on cmr-search

# Testing

Added new tests for readable_granule_name. Added a test for "True" vs "true" in options during url building.

### Example Query
```python
from datetime import datetime
from cmr import GranuleQuery

api = GranuleQuery()

granules = (
    api.short_name("MOD09GA")
    .version("061")
    .temporal(datetime(2023,2,20),datetime(2023,2,20,23,59,59))
    .readable_granule_name(["*h32v08*","*h30v13*"])
    .get_all()
)

for granule in granules:
    print(granule["title"])
```
### Results
```
MOD09GA.A2023051.h30v13.061.2023055133223
MOD09GA.A2023051.h32v08.061.2023055135421
```

