### PR TITLE
Fix cmr search after key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [pull/27](https://github.com/nasa/python_cmr/pull/27) New feature to search by `readable_granlue_name` https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#g-granule-ur-or-producer-granule-id
 ### Fixed
 - [pull/27](https://github.com/nasa/python_cmr/pull/27) Fixed bug with constructing the `options` sent to CMR which was causing filters to not get applied correctly.
+- [pull/28](https://github.com/nasa/python_cmr/pull/28) Fixed bug where `KeyError` was thrown if search result contained 0 hits
 
 ## [0.9.0]
 ### Added

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -59,7 +59,7 @@ class Query(object):
             response = get(url, headers=self.headers, params={'page_size': page_size})
             if self.headers == None:
                 self.headers = {}
-            self.headers['cmr-search-after'] = response.headers['cmr-search-after']
+            self.headers['cmr-search-after'] = response.headers.get('cmr-search-after')
 
             try:
                 response.raise_for_status()

--- a/tests/fixtures/vcr_cassettes/MOD09GA061_nohits.yaml
+++ b/tests/fixtures/vcr_cassettes/MOD09GA061_nohits.yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://cmr.earthdata.nasa.gov/search/granules.json?short_name=MOD09GA&version=061&temporal%5B%5D=1990-01-01T00:00:00Z,1990-01-02T00:00:00Z&page_size=2000
+  response:
+    body:
+      string: '{"feed":{"updated":"2024-03-19T01:45:43.818Z","id":"https://cmr.earthdata.nasa.gov:443/search/granules.json?short_name=MOD09GA&version=061&temporal%5B%5D=1990-01-01T00:00:00Z,1990-01-02T00:00:00Z&page_size=2000","title":"ECHO
+        granule metadata","entry":[]}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '0'
+      CMR-Request-Id:
+      - 211cef0c-67e7-4233-86c4-716bb79ae77d
+      CMR-Took:
+      - '17'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Tue, 19 Mar 2024 01:45:43 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      Via:
+      - 1.1 c8c9787916110356915bbdbddd0a32d6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - B1Ro_QV_1jxT6j_JD9v_vH0uJaxzpwS1-wYiLga59S08cpmZuuNNXQ==
+      X-Amz-Cf-Pop:
+      - IAD89-C2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - B1Ro_QV_1jxT6j_JD9v_vH0uJaxzpwS1-wYiLga59S08cpmZuuNNXQ==
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '256'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_multiple_queries.py
+++ b/tests/test_multiple_queries.py
@@ -1,5 +1,6 @@
 import unittest
 import json
+from datetime import datetime
 
 import vcr
 import urllib.request
@@ -92,4 +93,21 @@ class TestMultipleQueries(unittest.TestCase):
             assert_unique_granules_from_results(granules)
             # Assert that we performed a hits query and two search results queries
             self.assertEqual(len(cass), 3)
+            self.assertIsNone(api.headers.get('cmr-search-after'))
+    
+    def test_zero_hits_query(self):
+        """
+        If we execute a get that has zero
+        hits, cmr-search-after is not sent in
+        the response headers
+        """
+        with my_vcr.use_cassette('tests/fixtures/vcr_cassettes/MOD09GA061_nohits.yaml') as cass:
+            api = GranuleQuery()
+            granules = (
+                api.short_name("MOD09GA")
+                .version("061")
+                .temporal(datetime(1990,1,1),datetime(1990,1,2))
+                .get()
+            )
+            self.assertEqual(len(granules), 0)
             self.assertIsNone(api.headers.get('cmr-search-after'))


### PR DESCRIPTION
Hello!

During debugging adding readable_granule_name filter, I ran into key errors when making a request that returns zero hits. In these cases it looks like the CMR Search api does not send back `cmr-search-after` in the headers as expected in the code.

Added a fix, and new recorded tests that would have caught this

Please let me know if you have any questions or concerns