### PR TITLE
Fix KeyError for non-json query formats

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        poetry-version: ["1.7.1"]
+        poetry-version: ["1.8.2"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- [issues/35](https://github.com/nasa/python_cmr/issues/35) Eliminated accommodation for
-  Python versions older than 3.8 and updated CI build to test against Python versions
-  3.8 through 3.12.  Also, fixed all flake8 warnings.
+- [issues/35](https://github.com/nasa/python_cmr/issues/35) Eliminated
+  accommodation for Python versions older than 3.8 and updated CI build to test
+  against Python versions 3.8 through 3.12.  Also, fixed all flake8 warnings.
+
+## Fixed
+
+- [issues/42](https://github.com/nasa/python_cmr/issues/42) Fixed bug where a
+  `KeyError` was thrown from `Query.get` when the query format was a supported
+  format other than `"json"`.  Further, in such cases, too many items would be
+  fetched from the CMR due to a bug in how items were counted.  Now, no more
+  than `limit` items are fetched.
 
 ## [0.10.0]
 

--- a/tests/fixtures/vcr_cassettes/test_get_unparsed_format.yaml
+++ b/tests/fixtures/vcr_cassettes/test_get_unparsed_format.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://cmr.earthdata.nasa.gov/search/granules.umm_json?short_name=MOD02QKM&page_size=2
+  response:
+    body:
+      string: '{"hits":1380320,"took":168,"items":[{"meta":{"concept-type":"granule","concept-id":"G1462754234-LAADS","revision-id":4,"native-id":"LAADS:2715071895","collection-concept-id":"C1378579425-LAADS","provider-id":"LAADS","format":"application/echo10+xml","revision-date":"2022-11-22T11:54:22.375Z"},"umm":{"TemporalExtent":{"RangeDateTime":{"BeginningDateTime":"2000-02-24T00:05:00.000Z","EndingDateTime":"2000-02-24T00:10:00.000Z"}},"GranuleUR":"LAADS:2715071895","SpatialExtent":{"HorizontalSpatialDomain":{"Geometry":{"GPolygons":[{"Boundary":{"Points":[{"Longitude":146.932438,"Latitude":76.50228},{"Longitude":-145.553577,"Latitude":66.835767},{"Longitude":-94.815506,"Latitude":70.509885},{"Longitude":9.997243,"Latitude":84.145132},{"Longitude":146.932438,"Latitude":76.50228}]}}]}}},"ProviderDates":[{"Date":"2017-06-21T18:43:28.500Z","Type":"Insert"},{"Date":"2022-11-22T11:54:16.440Z","Type":"Update"}],"CollectionReference":{"ShortName":"MOD02QKM","Version":"6.1"},"PGEVersionClass":{"PGEVersion":"6.2.2_1"},"RelatedUrls":[{"URL":"https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOD02QKM/2000/055/MOD02QKM.A2000055.0005.061.2017171194850.hdf","Type":"GET
+        DATA","MimeType":"application/x-hdfeos"},{"URL":"s3://prod-lads/MOD02QKM/MOD02QKM.A2000055.0005.061.2017171194850.hdf","Type":"GET
+        DATA VIA DIRECT ACCESS","MimeType":"application/x-hdfeos"},{"URL":"https://ladsweb.modaps.eosdis.nasa.gov/opendap/RemoteResources/laads/allData/61/MOD02QKM/2000/055/MOD02QKM.A2000055.0005.061.2017171194850.hdf.html","Type":"USE
+        SERVICE API","Subtype":"OPENDAP DATA","Description":"This file may be accessed
+        using OPeNDAP directly from this link","MimeType":"text/html"},{"URL":"http://doi.org/10.5067/MODIS/MOD02QKM.061","Type":"VIEW
+        RELATED INFORMATION","Description":"A link to Data set landing page","MimeType":"text/html"},{"URL":"https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOBRGB/2000/055/MOBRGB.A2000055.0005.061.2017272125720.jpg","Type":"GET
+        RELATED VISUALIZATION","Description":"This Browse file may be downloaded directly
+        from this link","MimeType":"image/jpeg"}],"Projects":[{"ShortName":"Not provided","Campaigns":["Terra"]}],"DataGranule":{"DayNightFlag":"Both","Identifiers":[{"Identifier":"MOD02QKM.A2000055.0005.061.2017171194850.hdf","IdentifierType":"ProducerGranuleId"}],"ProductionDateTime":"2017-06-20T19:48:50.000Z","ArchiveAndDistributionInformation":[{"Name":"Not
+        provided","Size":26.6880235671997,"SizeInBytes":27984421,"Checksum":{"Value":"f354ac721cb0f66e1da78b420e734c6a","Algorithm":"MD5"},"SizeUnit":"MB"}]},"Platforms":[{"ShortName":"Terra","Instruments":[{"ShortName":"MODIS"}]}],"MetadataSpecification":{"URL":"https://cdn.earthdata.nasa.gov/umm/granule/v1.6.5","Name":"UMM-G","Version":"1.6.5"}}},{"meta":{"concept-type":"granule","concept-id":"G1462754407-LAADS","revision-id":4,"native-id":"LAADS:2715072177","collection-concept-id":"C1378579425-LAADS","provider-id":"LAADS","format":"application/echo10+xml","revision-date":"2022-11-22T11:54:25.006Z"},"umm":{"TemporalExtent":{"RangeDateTime":{"BeginningDateTime":"2000-02-24T00:10:00.000Z","EndingDateTime":"2000-02-24T00:15:00.000Z"}},"GranuleUR":"LAADS:2715072177","SpatialExtent":{"HorizontalSpatialDomain":{"Geometry":{"GPolygons":[{"Boundary":{"Points":[{"Longitude":150.408066,"Latitude":58.831248},{"Longitude":-171.273133,"Latitude":53.551985},{"Longitude":-145.975778,"Latitude":67.194745},{"Longitude":145.201467,"Latitude":76.970977},{"Longitude":150.408066,"Latitude":58.831248}]}}]}}},"ProviderDates":[{"Date":"2017-06-21T18:43:29.010Z","Type":"Insert"},{"Date":"2022-11-22T11:54:23.590Z","Type":"Update"}],"CollectionReference":{"ShortName":"MOD02QKM","Version":"6.1"},"PGEVersionClass":{"PGEVersion":"6.2.2_1"},"RelatedUrls":[{"URL":"https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOD02QKM/2000/055/MOD02QKM.A2000055.0010.061.2017171195126.hdf","Type":"GET
+        DATA","MimeType":"application/x-hdfeos"},{"URL":"s3://prod-lads/MOD02QKM/MOD02QKM.A2000055.0010.061.2017171195126.hdf","Type":"GET
+        DATA VIA DIRECT ACCESS","MimeType":"application/x-hdfeos"},{"URL":"https://ladsweb.modaps.eosdis.nasa.gov/opendap/RemoteResources/laads/allData/61/MOD02QKM/2000/055/MOD02QKM.A2000055.0010.061.2017171195126.hdf.html","Type":"USE
+        SERVICE API","Subtype":"OPENDAP DATA","Description":"This file may be accessed
+        using OPeNDAP directly from this link","MimeType":"text/html"},{"URL":"http://doi.org/10.5067/MODIS/MOD02QKM.061","Type":"VIEW
+        RELATED INFORMATION","Description":"A link to Data set landing page","MimeType":"text/html"},{"URL":"https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOBRGB/2000/055/MOBRGB.A2000055.0010.061.2017272130054.jpg","Type":"GET
+        RELATED VISUALIZATION","Description":"This Browse file may be downloaded directly
+        from this link","MimeType":"image/jpeg"}],"Projects":[{"ShortName":"Not provided","Campaigns":["Terra"]}],"DataGranule":{"DayNightFlag":"Day","Identifiers":[{"Identifier":"MOD02QKM.A2000055.0010.061.2017171195126.hdf","IdentifierType":"ProducerGranuleId"}],"ProductionDateTime":"2017-06-20T19:51:26.000Z","ArchiveAndDistributionInformation":[{"Name":"Not
+        provided","Size":45.6425333023071,"SizeInBytes":47859665,"Checksum":{"Value":"00d5aff45c4f45d0ae15476c347deb6f","Algorithm":"MD5"},"SizeUnit":"MB"}]},"Platforms":[{"ShortName":"Terra","Instruments":[{"ShortName":"MODIS"}]}],"MetadataSpecification":{"URL":"https://cdn.earthdata.nasa.gov/umm/granule/v1.6.5","Name":"UMM-G","Version":"1.6.5"}}}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1380320'
+      CMR-Request-Id:
+      - f71610d5-303d-4ae0-bbc4-7ec8598d8137
+      CMR-Search-After:
+      - '["laads",951351000000,1462754407]'
+      CMR-Took:
+      - '168'
+      Connection:
+      - keep-alive
+      Content-MD5:
+      - d8b879c60fb7fe8803d1ab67174f32d0
+      Content-SHA1:
+      - 809f983fd196fd99e70efbc34e220d9b0695541e
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.6.5; charset=utf-8
+      Date:
+      - Mon, 22 Apr 2024 22:50:21 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      Via:
+      - 1.1 a7253311f94fb967603a1d22f7a3c43a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - BHtGdv9GBfA_coialMikKw8daR3LCoxrzrmk99BUk7kvw8TQdEfuqQ==
+      X-Amz-Cf-Pop:
+      - PHL51-P1
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - BHtGdv9GBfA_coialMikKw8daR3LCoxrzrmk99BUk7kvw8TQdEfuqQ==
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '5465'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
Also, fix bug in result counting that caused up to _limit^2_ results to be feched rather than only _limit_ results.

Fixes #42