### PR TITLE
Add support for filtering cloud hosted collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- [issues/54](https://github.com/nasa/python_cmr/issues/54) Added support for searching for cloud-hosted collections.
+
+## [Unreleased]
+
 ### Fixed
 
 - [issues/48](https://github.com/nasa/python_cmr/issues/48) When a query's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - [issues/54](https://github.com/nasa/python_cmr/issues/54) Added support for searching for cloud-hosted collections.
 
-## [Unreleased]
-
 ### Fixed
 
 - [issues/48](https://github.com/nasa/python_cmr/issues/48) When a query's

--- a/README.md
+++ b/README.md
@@ -348,3 +348,10 @@ Run Tests
 ```shell
 poetry run pytest
 ```
+
+Run Type Checks
+---------------
+
+```shell
+poetry run mypy cmr tests
+```

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -919,13 +919,23 @@ class CollectionQuery(GranuleCollectionBaseQuery):
         self.params["service_concept_id"] = IDs
 
         return self
+
     def cloud_hosted(self, cloud_hosted: bool) -> Self:
         """
-        Filter collections to result only the ones that have a DirectDistributionInformation element 
-        or have been tagged with gov.nasa.earthdatacloud.s3
+        Filter collections to only those that are (or are not) hosted in cloud storage.
+        A cloud-hosted collection either has a `DirectDistributionInformation` element 
+        or is tagged with `gov.nasa.earthdatacloud.s3`.
+        
+        When this method is _not_ invoked, the query results may contain a mix of
+        cloud-hosted and non-cloud-hosted (on-premise) collections.
 
-        :param cloud_hosted: True to require the above results
+        :param cloud_hosted: `True` to select _only_ cloud-hosted collections; `False` to
+            select only _non_-cloud-hosted (on-premise) collections
         :returns: self
+
+        ..seealso::
+           `Find collections with data that is hosted in the cloud. <https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#c-cloud-hosted>`_
+              Documentation for finding cloud-hosted collections with the CMR Search API.
         """
         if not isinstance(cloud_hosted, bool):
             raise TypeError("Cloud hosted must be of type bool")
@@ -933,7 +943,6 @@ class CollectionQuery(GranuleCollectionBaseQuery):
         self.params["cloud_hosted"] = cloud_hosted
 
         return self
-
 
     @override
     def _valid_state(self) -> bool:

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -919,6 +919,21 @@ class CollectionQuery(GranuleCollectionBaseQuery):
         self.params["service_concept_id"] = IDs
 
         return self
+    def cloud_hosted(self, cloud_hosted: bool) -> Self:
+        """
+        Filter collections to result only the ones that have a DirectDistributionInformation element 
+        or have been tagged with gov.nasa.earthdatacloud.s3
+
+        :param cloud_hosted: True to require the above results
+        :returns: self
+        """
+        if not isinstance(cloud_hosted, bool):
+            raise TypeError("Cloud hosted must be of type bool")
+        
+        self.params["cloud_hosted"] = cloud_hosted
+
+        return self
+
 
     @override
     def _valid_state(self) -> bool:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -104,10 +104,10 @@ class TestCollectionClass(unittest.TestCase):
         query.cloud_hosted(True)
 
         self.assertIn("cloud_hosted", query.params)
-        self.assertEqual(query.params["cloud_hosted"], [True])
+        self.assertEqual(query.params["cloud_hosted"], True)
 
     def test_invalid_cloud_hosted(self):
         query = CollectionQuery()
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             query.cloud_hosted("Test_string_for_cloud_hosted_param")

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -98,3 +98,16 @@ class TestCollectionClass(unittest.TestCase):
 
         self.assertIn("Authorization", query.headers)
         self.assertEqual(query.headers["Authorization"], "Bearer 123TOKEN")
+
+    def test_cloud_hosted(self):
+        query = CollectionQuery()
+        query.cloud_hosted(True)
+
+        self.assertIn("cloud_hosted", query.params)
+        self.assertEqual(query.params["cloud_hosted"], [True])
+
+    def test_invalid_cloud_hosted(self):
+        query = CollectionQuery()
+
+        with self.assertRaises(ValueError):
+            query.cloud_hosted("Test_string_for_cloud_hosted_param")

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -110,4 +110,4 @@ class TestCollectionClass(unittest.TestCase):
         query = CollectionQuery()
 
         with self.assertRaises(TypeError):
-            query.cloud_hosted("Test_string_for_cloud_hosted_param")
+            query.cloud_hosted("Test_string_for_cloud_hosted_param")  # type: ignore[arg-type]


### PR DESCRIPTION
As per: https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#c-cloud-hosted