### PR TITLE
Add option to search by revision_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Support searching for cloud-hosted collections
   ([#54](https://github.com/nasa/python_cmr/issues/54))
+- Option to search for collections and granules by `revision_date` ([#67](https://github.com/nasa/python_cmr/issues/67))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ api.temporal("2016-10-10T01:02:00Z", "2016-10-12T00:00:30Z")
 api.temporal("2016-10-10T01:02:00Z", None)
 api.temporal(datetime(2016, 10, 10, 1, 2, 0), datetime.now())
 
+# search for granules by revision_date
+api.revision_date("2022-05-16", "2024-06-30")
+
 # only include granules available for download
 api.downloadable()
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -111,3 +111,8 @@ class TestCollectionClass(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             query.cloud_hosted("Test_string_for_cloud_hosted_param")  # type: ignore[arg-type]
+
+    def test_revision_date(self):
+        query = CollectionQuery()
+        collections = query.short_name("SWOT_L2_HR_RiverSP_reach_2.0").revision_date("2022-05-16", "2024-06-30").get_all()
+        self.assertEqual(collections[0]["dataset_id"], "SWOT Level 2 River Single-Pass Vector Reach Data Product, Version 2.0")

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -1,5 +1,6 @@
-import unittest
 from datetime import datetime, timezone, timedelta
+import json
+import unittest
 
 from cmr.queries import GranuleQuery
 
@@ -64,6 +65,20 @@ class TestGranuleClass(unittest.TestCase):
 
         self.assertIn(self.circle, query.params)
         self.assertEqual(query.params[self.circle], "10.0,15.1,1000")
+        
+    def test_revision_date(self):
+        query = GranuleQuery()
+        granules = query.short_name("SWOT_L2_HR_RiverSP_reach_2.0").revision_date("2024-07-05", "2024-07-05").format("umm_json").get_all()
+        granule_dict = {}
+        for granule in granules:
+            granule_json = json.loads(granule)
+            for item in granule_json["items"]:
+                native_id = item["meta"]["native-id"]
+                granule_dict[native_id] = item
+        
+        self.assertIn("SWOT_L2_HR_RiverSP_Reach_017_312_AS_20240630T042656_20240630T042706_PIC0_01_swot", granule_dict.keys())
+        self.assertIn("SWOT_L2_HR_RiverSP_Reach_017_310_SI_20240630T023426_20240630T023433_PIC0_01_swot", granule_dict.keys())
+        self.assertIn( "SWOT_L2_HR_RiverSP_Reach_017_333_EU_20240630T225156_20240630T225203_PIC0_01_swot", granule_dict.keys())
 
     def test_temporal_invalid_strings(self):
         query = GranuleQuery()


### PR DESCRIPTION
Github Issue: #67

### Description

Add option to search for granules by `revision_date`. The `revision_date` parameter allows a search to be performed on the granule or collection level for any granules or collections that have been updated.

### Overview of work done

- Add `revision_date` function to `GranuleCollectionBaseQuery`.

### Overview of verification done

Created two new unit tests

1) Test query of CMR by revision date for collections
2) Test query of CMR by revision date for granules

New and existing unit tests pass.
