### PR TITLE
updated adding instance_format to variable query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Support multi-point searches ([#72](https://github.com/nasa/python_cmr/issues/72))
 - Support `processing_level_id` in `CollectionQuery` ([#76](https://github.com/nasa/python_cmr/issues/76))
 - Support `platform` in `CollectionQuery` ([#77](https://github.com/nasa/python_cmr/issues/77))
-- Support `instance-format` to `VariableQuery` to allow for searching of variable zarr stores ([#59]https://github.com/nasa/python_cmr/issues/59)
+- Support searching by instance format for `VariableQuery` ([#59]https://github.com/nasa/python_cmr/issues/59)
 
 ### Fixed
 - Setup vcrpy for new `revision_date` unit tests ([#70](https://github.com/nasa/python_cmr/issues/70))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Support multi-point searches ([#72](https://github.com/nasa/python_cmr/issues/72))
 - Support `processing_level_id` in `CollectionQuery` ([#76](https://github.com/nasa/python_cmr/issues/76))
 - Support `platform` in `CollectionQuery` ([#77](https://github.com/nasa/python_cmr/issues/77))
+- Support `instance-format` to `VariableQuery` to allow for searching of variable zarr stores ([#59]https://github.com/nasa/python_cmr/issues/59)
 
 ### Fixed
 - Setup vcrpy for new `revision_date` unit tests ([#70](https://github.com/nasa/python_cmr/issues/70))

--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ api.name('/AMR_Side_1/acc_lat')
 
 # Search via concept_id
 api.concept_id('V2112019824-POCLOUD')
+
+# Search via instance format
+query.instance_format(["zarr", "kerchunk"])
 ```
 
 As an alternative to chaining methods together to set the parameters of your query, a method exists to allow you to pass

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -1210,6 +1210,19 @@ class VariableQuery(ToolServiceVariableBaseQuery):
             "dif", "dif10", "opendata", "umm_json", "umm_json_v[0-9]_[0-9]"
         ])
 
+    def instance_format(self, instance_format: str) -> Self:
+        """
+        Filter by instance format.
+
+        :param instance_format: format for variable instance
+        :returns: self
+        """
+
+        if instance_format: 
+            self.params['instance_format'] = instance_format 
+        
+        return self
+    
     @override
     def _valid_state(self) -> bool:
         return True

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -1210,19 +1210,21 @@ class VariableQuery(ToolServiceVariableBaseQuery):
             "dif", "dif10", "opendata", "umm_json", "umm_json_v[0-9]_[0-9]"
         ])
 
-    def instance_format(self, instance_format: str) -> Self:
+    def instance_format(self, format: Union[str, Sequence[str]]) -> Self:
         """
-        Filter by instance format.
+        Filter by instance format(s), matching any one of the specified formats.
+        Does nothing if `format` is an empty string or an empty sequence.
 
-        :param instance_format: format for variable instance
+        :param format: format(s) for variable instance (a single string, or sequence of
+            strings)
         :returns: self
         """
 
-        if instance_format: 
-            self.params['instance_format'] = instance_format 
+        if format:
+            # Assume we have non-empty string or sequence of strings (list, tuple, etc.)
+            self.params['instance_format'] = [format] if isinstance(format, str) else format
         
         return self
-    
     @override
     def _valid_state(self) -> bool:
         return True

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -85,3 +85,10 @@ class TestVariableClass(unittest.TestCase):
 
         self.assertIn("Authorization", query.headers)
         self.assertEqual(query.headers["Authorization"], "Bearer 123TOKEN")
+
+    def test_instance_format(self):
+        query = VariableQuery()
+        query.instance_format("zarr")
+
+        self.assertIn("instance_format", query.params)
+        self.assertEqual(query.params["instance_format"], "zarr")

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -91,4 +91,11 @@ class TestVariableClass(unittest.TestCase):
         query.instance_format("zarr")
 
         self.assertIn("instance_format", query.params)
-        self.assertEqual(query.params["instance_format"], "zarr")
+        self.assertEqual(query.params["instance_format"], ["zarr"])
+
+    def test_instance_formats(self):
+        query = VariableQuery()
+        query.instance_format(["zarr", "kerchunk"])
+
+        self.assertIn("instance_format", query.params)
+        self.assertEqual(query.params["instance_format"], ["zarr", "kerchunk"])


### PR DESCRIPTION
Following the conversation here: https://github.com/nasa/python_cmr/issues/59
NASA GES DISC is releasing public zarr stores for specific variables of collections. The only way to discover what available zarr stores at variable level is via the CMR parameter instance_format. This simple PR adds this as a search parameter in VariablesQuery.

Closed last PR as it fell behind other commits: https://github.com/nasa/python_cmr/pull/60 

Should encompass all feedback 