### PR TITLE
Support multiple platform filters

### DIFF
--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -774,16 +774,28 @@ class GranuleCollectionBaseQuery(Query):
 
         return self
 
-    def platform(self, platform: str) -> Self:
+    def platform(
+        self,
+        platform: Union[str, Sequence[str]],
+        *platforms: str,
+    ) -> Self:
         """
         Filter by the satellite platform the granule came from.
 
-        :param platform: name of the satellite
+        :param platform: name(s) of the satellite platform
         :returns: self
         """
 
         if not platform:
             raise ValueError("Please provide a value for platform")
+
+        if platforms:
+            if not isinstance(platform, str):
+                raise TypeError(
+                    "Platform must be of type str when providing multiple "
+                    "arguments"
+                )
+            platform = [platform, *platforms]
 
         self.params['platform'] = platform
         return self

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -144,6 +144,22 @@ class TestCollectionClass(VCRTestCase):  # type: ignore
         self.assertIn("platform", query.params)
         self.assertEqual(query.params["platform"], "1B")
 
+    def test_multiple_platforms(self):
+        query = CollectionQuery()
+
+        query.platform("Aqua", "Terra")
+
+        self.assertIn("platform", query.params)
+        self.assertEqual(query.params["platform"], ["Aqua", "Terra"])
+
+    def test_multiple_platforms_from_list(self):
+        query = CollectionQuery()
+
+        query.platform(["Aqua", "Terra"])
+
+        self.assertIn("platform", query.params)
+        self.assertEqual(query.params["platform"], ["Aqua", "Terra"])
+
     def test_empty_platform(self):
         query = CollectionQuery()
 

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -344,6 +344,22 @@ class TestGranuleClass(VCRTestCase):  # type: ignore
         self.assertIn(self.platform, query.params)
         self.assertEqual(query.params[self.platform], "1B")
 
+    def test_multiple_platforms(self):
+        query = GranuleQuery()
+
+        query.platform("Aqua", "Terra")
+
+        self.assertIn(self.platform, query.params)
+        self.assertEqual(query.params[self.platform], ["Aqua", "Terra"])
+
+    def test_multiple_platforms_from_list(self):
+        query = GranuleQuery()
+
+        query.platform(["Aqua", "Terra"])
+
+        self.assertIn(self.platform, query.params)
+        self.assertEqual(query.params[self.platform], ["Aqua", "Terra"])
+
     def test_sort_key(self):
         query = GranuleQuery()
         # Various sort keys using this as an example


### PR DESCRIPTION
## Summary
- allow collection and granule platform filters to accept multiple platform values
- preserve existing single-platform behavior
- add tests for variadic and list-based platform filters

Fixes #80.

## Validation
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m mypy cmr tests`
- `git diff --check`

Note: full flake8 currently reports existing line-length issues across the repository, unrelated to this change.