### PR TITLE
feat: add client_id() header method and multi-platform search support

### DIFF
--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -5,6 +5,7 @@ Contains all CMR query types.
 from abc import abstractmethod
 from collections import defaultdict
 from datetime import date, datetime, timezone
+from importlib.metadata import version as _pkg_version
 from inspect import getmembers, ismethod
 from re import search
 from typing import Iterator
@@ -362,6 +363,34 @@ class Query:
             return self
 
         self.headers.update({"Authorization": f"Bearer {bearer_token}"})
+
+        return self
+
+    def client_id(self, client_id: Optional[str] = None) -> Self:
+        """
+        Set the ``Client-Id`` header to identify this client to the CMR API.
+
+        If no *client_id* is provided (or ``None`` is passed), a default value
+        of ``python_cmr-<version>`` is used so that NASA Operations can track
+        queries by library version.
+
+        :param client_id: an optional human-readable identifier for your
+            application.  When supplied, the string is suffixed with the
+            library version: ``<client_id>/python_cmr-<version>``.
+        :returns: self
+        """
+
+        try:
+            lib_version = _pkg_version("python-cmr")
+        except Exception:
+            lib_version = "unknown"
+
+        if client_id:
+            header_value = f"{client_id}/python_cmr-{lib_version}"
+        else:
+            header_value = f"python_cmr-{lib_version}"
+
+        self.headers.update({"Client-Id": header_value})
 
         return self
 
@@ -774,18 +803,25 @@ class GranuleCollectionBaseQuery(Query):
 
         return self
 
-    def platform(self, platform: str) -> Self:
+    def platform(self, platform: Union[str, Sequence[str]]) -> Self:
         """
         Filter by the satellite platform the granule came from.
 
-        :param platform: name of the satellite
+        Accepts either a single platform name or a list of platform names.
+        When multiple platforms are provided, CMR returns results matching
+        any of them.
+
+        :param platform: name of the satellite, or a list of satellite names
         :returns: self
         """
 
         if not platform:
             raise ValueError("Please provide a value for platform")
 
-        self.params['platform'] = platform
+        if isinstance(platform, str):
+            platform = [platform]
+
+        self.params['platform'] = list(platform)
         return self
 
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -142,7 +142,15 @@ class TestCollectionClass(VCRTestCase):  # type: ignore
         query.platform("1B")
 
         self.assertIn("platform", query.params)
-        self.assertEqual(query.params["platform"], "1B")
+        self.assertEqual(query.params["platform"], ["1B"])
+
+    def test_platform_multiple(self):
+        query = CollectionQuery()
+
+        query.platform(["Terra", "Aqua"])
+
+        self.assertIn("platform", query.params)
+        self.assertEqual(query.params["platform"], ["Terra", "Aqua"])
 
     def test_empty_platform(self):
         query = CollectionQuery()

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -342,7 +342,15 @@ class TestGranuleClass(VCRTestCase):  # type: ignore
         query.platform("1B")
 
         self.assertIn(self.platform, query.params)
-        self.assertEqual(query.params[self.platform], "1B")
+        self.assertEqual(query.params[self.platform], ["1B"])
+
+    def test_platform_multiple(self):
+        query = GranuleQuery()
+
+        query.platform(["Terra", "Aqua"])
+
+        self.assertIn(self.platform, query.params)
+        self.assertEqual(query.params[self.platform], ["Terra", "Aqua"])
 
     def test_sort_key(self):
         query = GranuleQuery()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -55,3 +55,28 @@ def test_token_replaces_existing_auth_header():
     query.token("token")
 
     assert query.headers["Authorization"] == "token"
+
+
+def test_client_id_default_uses_library_version():
+    query = MockQuery("/foo")
+    query.client_id()
+
+    assert "Client-Id" in query.headers
+    assert query.headers["Client-Id"].startswith("python_cmr-")
+
+
+def test_client_id_custom_includes_app_name_and_version():
+    query = MockQuery("/foo")
+    query.client_id("my-app")
+
+    assert "Client-Id" in query.headers
+    assert query.headers["Client-Id"].startswith("my-app/python_cmr-")
+
+
+def test_client_id_does_not_clobber_other_headers():
+    query = MockQuery("/foo")
+    query.headers["Authorization"] = "Bearer token"
+    query.client_id("my-app")
+
+    assert query.headers["Authorization"] == "Bearer token"
+    assert "Client-Id" in query.headers


### PR DESCRIPTION
Closes #49, closes #80.

## Changes

### `client_id()` method on `Query` (fixes #49)

Adds a `client_id(client_id=None)` convenience method to the `Query` base class, analogous to `token()` and `bearer_token()`, that sets the `Client-Id` header described in the [CMR Search API docs](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#headers).

- **Without an argument** (or `None`): sets `Client-Id: python_cmr-<version>` so that NASA Operations can identify requests from this library automatically.
- **With a string argument**: sets `Client-Id: <your-app>/python_cmr-<version>`, appending the library version for traceability.

```python
query = CollectionQuery().client_id()             # Client-Id: python_cmr-0.14.0
query = CollectionQuery().client_id("my-tool")   # Client-Id: my-tool/python_cmr-0.14.0
```

### Multi-platform support in `platform()` (fixes #80)

Updates `GranuleCollectionBaseQuery.platform()` to accept either a single string or a list of strings, matching CMR's native support for filtering by multiple platforms.

```python
# single platform (existing behaviour preserved)
query.platform("Terra")

# multiple platforms
query.platform(["Terra", "Aqua"])
```

## Tests
- 3 new tests in `tests/test_queries.py` covering `client_id()` default, custom name, and header isolation.
- 2 new tests (one per `GranuleQuery` and `CollectionQuery`) for multi-platform lists.
- Existing single-platform assertions updated to reflect the new list storage format.