### PR TITLE
Avoid scientific notation in point query parameters

### DIFF
--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -4,6 +4,7 @@ Contains all CMR query types.
 
 from abc import abstractmethod
 from collections import defaultdict
+from decimal import Decimal
 from datetime import date, datetime, timezone
 from inspect import getmembers, ismethod
 from re import search
@@ -625,7 +626,17 @@ class GranuleCollectionBaseQuery(Query):
         if "point" not in self.params:
             self.params["point"] = []
 
-        self.params["point"].append(f"{lon},{lat}")
+        # CMR rejects scientific notation in point query parameters.
+        lon_as_str = format(Decimal(str(lon)), "f")
+        lat_as_str = format(Decimal(str(lat)), "f")
+
+        if "." not in lon_as_str:
+            lon_as_str += ".0"
+
+        if "." not in lat_as_str:
+            lat_as_str += ".0"
+
+        self.params["point"].append(f"{lon_as_str},{lat_as_str}")
 
         return self
 

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -505,6 +505,12 @@ class TestGranuleClass(VCRTestCase):  # type: ignore
         self.assertEqual(query.params["version"], "003")
         self.assertEqual(query.params["point"], ["-100.0,42.0"])
 
+    def test_point_avoids_scientific_notation(self):
+        query = GranuleQuery().short_name("FOO").point(42, 0.00001)
+
+        self.assertEqual(query.params["point"], ["42.0,0.00001"])
+        self.assertIn("point[]=42.0,0.00001", query._build_url())
+
     def test_invalid_parameters(self):
         query = GranuleQuery()
 


### PR DESCRIPTION
Fixes #108.

`point()` now serializes coordinates in plain decimal form before building the URL, so values like `0.00001` stay as `0.00001` instead of `1e-05`.

I also added a regression test that checks both the stored point value and the generated query string.

Verification:
- `python3 -m pytest tests/test_granule.py tests/test_queries.py`
